### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 
 `$ npm install react-native-mds --save`
 
+### RN 60 and later
+
+add `Movesense` to your `ios/Podfile`
+
+```
+pod 'Movesense', :git => 'ssh://git@altssh.bitbucket.org:443/suunto/movesense-mobile-lib.git'
+```
+
 ### Mostly automatic installation
 
 `$ react-native link react-native-mds`

--- a/ios/BleController.swift
+++ b/ios/BleController.swift
@@ -8,7 +8,7 @@ final class BleController: NSObject, CBCentralManagerDelegate {
     private var centralManager : CBCentralManager?
     private var scanTimer = Timer() //!< When timer triggers, scanning is stopped
     private var knownDevices = Dictionary<UUID, String>() //!< Map UUID to Serial
-    private var knownDevicesFetched : Optional<() -> ()>
+    private var knownDevicesFetched : Optional<() -> ()> = nil
     var bleOnOff : ((Bool) -> ())?
     private var addDeviceCallback : (MovesenseDevice) -> () = { (device) in }
     
@@ -92,7 +92,7 @@ final class BleController: NSObject, CBCentralManagerDelegate {
     }
     
     private func isMovesense(_ localName: String) -> Bool {
-        let index = localName.characters.index(of: " ") ?? localName.endIndex
+        let index = localName.firstIndex(of: " ") ?? localName.endIndex
         return localName[localName.startIndex..<index] == "Movesense"
     }
     

--- a/ios/MdsService.swift
+++ b/ios/MdsService.swift
@@ -14,6 +14,10 @@ final public class MdsService: NSObject {
         self.mds = MDSWrapper()
         self.bleController = BleController()
     }
+
+    deinit {
+        self.shutdown()
+    }
     
     public func shutdown() {
         self.mds!.deactivate();

--- a/ios/RNMds.podspec
+++ b/ios/RNMds.podspec
@@ -6,19 +6,17 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNMds
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/tugberka/react-native-mds"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }
-  s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNMds.git", :tag => "master" }
-  s.source_files  = "RNMds/**/*.{h,m}"
+  s.platform     = :ios, "11.0"
+
+  s.source       = { :git => "https://github.com/tugberka/react-native-mds.git", :tag => "master" }
+  s.source_files  = "*.{h,m}", "*.swift"
   s.requires_arc = true
 
 
   s.dependency "React"
-  #s.dependency "others"
-
+  s.dependency "Movesense"
 end
-
-  

--- a/ios/ReactMds.swift
+++ b/ios/ReactMds.swift
@@ -10,7 +10,7 @@ import Foundation
 
 @objc(ReactMds)
 public final class ReactMds: RCTEventEmitter {
-    let mds = MdsService()
+    lazy var mds = MdsService()
     var subscriptions: Dictionary<String, String>  = [:]
 
     override init() {

--- a/ios/ReactMds.swift
+++ b/ios/ReactMds.swift
@@ -16,8 +16,12 @@ public final class ReactMds: RCTEventEmitter {
     override init() {
         super.init()
     }
-    
-    @objc open override func supportedEvents() -> [String] {
+
+    @objc static public override func requiresMainQueueSetup() -> Bool {
+        return true;
+    }
+
+    @objc public override func supportedEvents() -> [String] {
         var allEventNames: [String] = ["newScannedDevice", "newNotification", "newNotificationError"]
         return allEventNames
     }

--- a/src/MDSImpl.js
+++ b/src/MDSImpl.js
@@ -83,7 +83,7 @@ function MDSImpl() {
 	}
 
 	this.handleNewNotificationError = function(e: Event) {
-		self.subsErrorCbs[getIdxFromKey(e.key)](e.notification);
+		self.subsErrorCbs[getIdxFromKey(e.key)](e.error);
 	}
 
 	this.scan = function(scanHandler) {


### PR DESCRIPTION
Some fixes:

1. RN normal Reload was causing deadlock as two `MdsService` was alive. (New ReactMds is created when the old was not dealloced). Fixed by making `Mds` lazy.

2. I needed to use `connect` without `scan`, as i was using `react-native-ble-plx` for scanning, but it was not working as `newNotification` was only registered on scan.

3. Fixed warning about requiresMainQueueSetup

4. Error callbacks got undefined as parameter, instead of Reason of error.